### PR TITLE
Removed hardcoded rain resolution

### DIFF
--- a/src/clj/forma/hadoop/jobs/scatter.clj
+++ b/src/clj/forma/hadoop/jobs/scatter.clj
@@ -197,7 +197,7 @@
                  (?- (hfs-seqfile rain-path)
                      (mk-filter vcf-path
                                 (new-adjusted-precl-tap
-                                 ts-pail-path "1000" "32" t-res))))
+                                 ts-pail-path s-res "32" t-res))))
 
               reli-step
               ([:tmp-dirs reli-path]


### PR DESCRIPTION
There was a straggler hardcoded resolution in formarunner in scatter.clj. This pull request converts that hc string to a s-res variable, which is used elsewhere within formarunner.
