### PR TITLE
Wrapped get-vals for use with Cascalog, added test

### DIFF
--- a/src/clj/forma/hadoop/jobs/forma.clj
+++ b/src/clj/forma/hadoop/jobs/forma.clj
@@ -37,7 +37,7 @@
       (vcf-src _ ?vcf-chunk)
       (get-loc ?ts-chunk :> ?s-res ?mod-h ?mod-v ?sample ?line ?series)
       (schema/unpack-timeseries ?series :> ?start _ ?ts)
-      (schema/get-vals ?ts :> ?vals)
+      (schema/get-vals-wrap ?ts :> ?vals)
       (p/blossom-chunk ?vcf-chunk :> ?s-res ?mod-h ?mod-v ?sample ?line ?vcf)
       (>= ?vcf vcf-limit)
       (:distinct false)))

--- a/src/clj/forma/schema.clj
+++ b/src/clj/forma/schema.clj
@@ -119,6 +119,12 @@
 (defn count-vals [x]
   (count (get-vals x)))
 
+(defn get-vals-wrap
+  "Wrap get-vals so that returned vector is sufficiently nested for use in a
+   Cascalog query"
+  [array-obj]
+  [(get-vals array-obj)])
+
 (defn boundaries
   "Accepts a sequence of pairs of <initial time period, collection>
   and returns the maximum start period and the minimum end period. For

--- a/test/forma/schema_test.clj
+++ b/test/forma/schema_test.clj
@@ -89,3 +89,8 @@
         val (LocationPropertyValue/pixelLocation modis-pixel)
         locprop (LocationProperty. val)]
     (pixel-prop-location locprop) => modis-pixel))
+
+(fact
+  "Test vector wrapping of get-vals"
+  (let [arr (mk-array-value (DoubleArray. [1 2 3]))]
+    (get-vals-wrap arr)) => [[1 2 3]])


### PR DESCRIPTION
Need to be able to get array values out of a thrift object with appropriate nesting for use with Cascalog. This simple wrapper does that.
