### PR TITLE
Fixed running-fire-sum and added tests

### DIFF
--- a/src/clj/forma/hadoop/jobs/timeseries.clj
+++ b/src/clj/forma/hadoop/jobs/timeseries.clj
@@ -96,7 +96,7 @@
   (when (seq tseries)
     (->> tseries
          (reductions schema/add-fires)
-         (schema/timeseries-value start))))
+         (schema/fire-series start))))
 
 (defn aggregate-fires
   "Converts the datestring into a time period based on the supplied


### PR DESCRIPTION
Fixed cause of error `clojure.lang.LazySeq cannot be cast to org.apache.thrift.TUnion` in `running-fire-sum`. Also added a test of this op and fixed a separate test that was failing after thrift conversion.

Stacktrace: https://gist.github.com/7969060179fa468dfe25
