### PR TITLE
Drop pixels with neighbors on coast (coast pixels dist2border = 1)

### DIFF
--- a/src/clj/forma/hadoop/jobs/scatter.clj
+++ b/src/clj/forma/hadoop/jobs/scatter.clj
@@ -61,11 +61,12 @@
   (let [[vcf hansen ecoid gadm border]
         (map (comp static-tap (partial split-chunk-tap pail-path))
              [["vcf"] ["hansen"] ["ecoid"] ["gadm"] ["border"]])]
-    (<- [?s-res ?mod-h ?mod-v ?sample ?line ?gadm ?vcf ?ecoid ?hansen]
+    (<- [?s-res ?mod-h ?mod-v ?sample ?line ?gadm ?vcf ?ecoid ?hansen ?coast-dist]
         (vcf    ?s-res ?mod-h ?mod-v ?sample ?line ?vcf)
         (hansen ?s-res ?mod-h ?mod-v ?sample ?line ?hansen)
         (ecoid  ?s-res ?mod-h ?mod-v ?sample ?line ?ecoid)
         (gadm   ?s-res ?mod-h ?mod-v ?sample ?line ?gadm)
+        (border ?s-res ?mod-h ?mod-v ?sample ?line ?coast-dist)
         (>= ?vcf vcf-limit))))
 
 ;; ## Forma
@@ -91,7 +92,8 @@
              :window 10
              :ridge-const 1e-8
              :convergence-thresh 1e-6
-             :max-iterations 500}})
+             :max-iterations 500
+             :min-coast-dist 3}})
 
 (defn constrained-tap
   [ts-pail-path dataset s-res t-res]


### PR DESCRIPTION
Dropping all pixels that are adjacent to water (dist2border = 1) and pixels whose neighbors are adjacent to water (dist2border = 2). The idea is that the centroid of a pixel could be on the beach, which means it's half water, half land, and therefore messy. The next pixel inland (dist2border = 2) would have this water pixel as its neighbor, so that muddies the signal as well (no pun intended).

Neighborhoods are determined prior to screening, so a pixel with dist2border = 3 would still contain the information from its nearly coastal neighbor with dist2border = 2. But the pixel with dist2border = 2 would not be used to calculate the beta vector.
