### PR TITLE
Add Thrift API

### DIFF
--- a/src/clj/forma/thrift.clj
+++ b/src/clj/forma/thrift.clj
@@ -248,11 +248,18 @@
 
 (defn TimeSeries*
   "Create a TimeSeries."
-  [start end val]
+  ([start vals]
+    {:pre [(instance? java.lang.Long start)
+           (coll? vals)]}
+    (let [elems (count vals)]
+      (TimeSeries* start
+                   (dec (+ start (count vals)))
+                   vals)))
+  ([start end val]
     {:pre [(every? #(instance? java.lang.Long %) [start end])
            (coll? val)]}
     (let [series (if (coll? val) (pack val) val)]
-      (TimeSeries. start end (mk-array-value series))))
+      (TimeSeries. start end (mk-array-value series)))))
 
 (defn FormaValue*
   "Create a FormaValue."

--- a/test/forma/thrift_test.clj
+++ b/test/forma/thrift_test.clj
@@ -46,9 +46,9 @@
   (unpack (DataValue/doubleVal 1)) => 1.0)
 
 (fact "Check creating and unpacking TimeSeries objects."
-  (TimeSeries* 0 1 [1 1 1 1]) =>
-  (TimeSeries. 0 1 (->> (vec (map int [1 1 1 1])) IntArray. ArrayValue/ints))
-
+  (TimeSeries* 0 3 [1 1 1 1]) => (TimeSeries. 0 3 (->> (vec (map int [1 1 1 1])) IntArray. ArrayValue/ints))
+  (TimeSeries* 0 [1 1 1 1]) => (TimeSeries. 0 3 (->> (vec (map int [1 1 1 1])) IntArray. ArrayValue/ints))
+  
   (unpack (TimeSeries* 0 1 [1 1 1 1])) =>
   [0 1 (->> (map int [1 1 1 1]) IntArray. ArrayValue/ints)])
 


### PR DESCRIPTION
This pull request rides on Sam's Thrift refactor in f4249ab9c06326acf02eb3dd47d73c16fec1e355. It basically just adds a `forma.thrift` namespace with a very simple API for creating, accessing, and unpacking our Thrift objects (defined in the `dev/forma.thrift` IDL). See docs in the `forma.thrift` namespace for usage examples. Tests are in `test/forma/thrift_test.clj`

Here's a quick overview of the API. We have functions for creating Thrift objects:

``` clojure
NeighborValue*
FireValue*
ModisChunkLocation*
ModisPixelLocation*
TimeSeries*
FormaValue*
DataChunk*
```

Here's creating a `TimeSeries`:

``` clojure
(TimeSeries* 0 1 [1.0 2.0 3.0])
;; #<TimeSeries TimeSeries(startIdx:0, endIdx:1, series:<ArrayValue doubles:DoubleArray(doubles:[1.0, 2.0, 3.0])>)>
```

To unpack Thrift objects, use the `unpack` function which returns a vector of Thrift object field values in the order specified in the IDL. Here's unpacking a `TimeSeries`:

``` clojure
(def ts (TimeSeries* 0 1 [1.0 2.0 3.0]))
(unpack ts)
;; [0 1 #<ArrayValue <ArrayValue doubles:DoubleArray(doubles:[1.0, 2.0, 3.0])>>]
```

Here's unpacking the `TimeSeries` series field:

``` clojure
(unpack (get-series ts)
;; [1.0 2.0 3.0]
```

Finally, in a Cascalog query, sometimes you want to wrap the results of `unpack` in a vector. For that just use the `unpack*` function which wraps results in a vector.
