### PR TITLE
hoptree fix

### DIFF
--- a/src/clj/forma/hoptree.clj
+++ b/src/clj/forma/hoptree.clj
@@ -93,7 +93,7 @@
   (util/idx->rowcol (:height window-map) (:width window-map) (:idx t)))
 
 (defmethod global-index WindowIndex [sres t & [window-map]]
-  (global-index sres (window-rowcol sres window-map t) window-map))
+  (global-index sres (WindowRowCol* (window-rowcol sres window-map t)) window-map))
 
 (defmulti global-rowcol (fn [sres t] (class t)))
 


### PR DESCRIPTION
A minor change to the MODIS pixel locator namespace, hoptree.  

I have thought a lot about the running discussion with Sam, and I am happy with this architecture.  We have only one thrift object for a MODIS pixel, which we have constructed so that the location is serializable.  I like having a clear and immediately accessible set of methods to move between pixel identifiers -- all built purely in Clojure.  I would like to stick to Clojure objects where possible; adding a thrift object to move between relative pixel identifiers seems to introduce a level of complexity that far outweighs the benefit of having all pixel identifiers in thrift.  We don't need the window identifier to be serializable, for example, and that would just confuse things.  I think it's easy enough to explain the purpose for having an additional thrift object, with the expressed and sole purpose of comparability in Cascalog.  That's not hard to explain.  

This API, of sorts, has been very helpful in thinking about processing neighbor attributes.  It is already serving its purpose.  

I also have responses to Sam's other comments; but I will find a better place to lay out my explanation.
