### PR TITLE
Feature/fix one off

### DIFF
--- a/src/clj/forma/hadoop/jobs/forma.clj
+++ b/src/clj/forma/hadoop/jobs/forma.clj
@@ -125,7 +125,7 @@
 (defmapop series-end
   [series start]
   (let [length (count series)]
-    (+ start length)))
+    (dec (+ start length))))
 
 (defn analyze-trends
   "Accepts an est-map, and sources for ndvi and rain timeseries and
@@ -198,7 +198,7 @@
   (let [start (date/datetime->period t-res (:est-start est-map))]
     (<- [?s-res ?period ?mh ?mv ?s ?l ?forma-val]
         (fire-src ?s-res ?mh ?mv ?s ?l !!fire)
-        (dynamic-src ?s-res ?mh ?mv ?s ?l _ ?end ?short ?long ?t-stat ?break)
+        (dynamic-src ?s-res ?mh ?mv ?s ?l _ _ ?short ?long ?t-stat ?break)
         (schema/forma-seq !!fire ?short ?long ?t-stat ?break :> ?forma-seq)
         (p/index ?forma-seq :zero-index start :> ?period ?forma-val)
         (:distinct false))))


### PR DESCRIPTION
This pull request restores a `dec` to a function that calculates the ending period of a timeseries based on the length of the timeseries array. The end period generated here without `dec` technically is incorrect. Fortunately, after reading through the subsequent usage of this function, I've determined that the one-off error does not affect the quality of output data, since it is only ever used for [ordering values](https://github.com/reddmetrics/forma-clj/blob/feature/deliver/src/clj/forma/hadoop/jobs/forma.clj#L153) - relative order, rather than absolute order based on dates or periods.

`?end` appeared [here](https://github.com/reddmetrics/forma-clj/blob/feature/deliver/src/clj/forma/hadoop/jobs/forma.clj#L201) but `p/index` just below it is actually used to ensure the correct ordering in that query. As a result, I've replaced `?end` with `_`
