### PR TITLE
Feature/hansen z20

### DIFF
--- a/src/clj/forma/gfw/cdm.clj
+++ b/src/clj/forma/gfw/cdm.clj
@@ -99,12 +99,6 @@
 ;; Map of lat/lon min and max values.
 (def latlon-range {:lat-min -90 :lat-max 90 :lon-min -180 :lon-max 180})
 
-(defn read-string->num
-  "Convert strings to number."
-  [& s]
-  {:pre [(every? string? s)]}
-  (vec (map read-string s)))
-
 (defn latlon-valid?
   [lat lon]
   "Returns true if lat and lon are valid, otherwise returns false."
@@ -146,7 +140,7 @@
         xt (-> (/ xp map-tile-dim)
                (Math/ceil)
                (- 1)
-                  (int))
+               (int))
         yt-flipped (-> (- (expt 2 zoom) 1)
                        (- yt))]
     [xt yt-flipped zoom]))

--- a/src/clj/forma/gfw/cdm.clj
+++ b/src/clj/forma/gfw/cdm.clj
@@ -75,21 +75,21 @@
                  (/ res))]
       [yp xp]))
 
-    (pixels->tile
-     [this]
-     "Returns this alert coordinates as map tile coordinates."
-     (let [[yp xp] (meters->pixels this)
-           res (resolution this)
-           yt (-> (/ yp map-tile-dim)
-                  (Math/ceil)
-                  (- 1)
-                  (int))
-           xt (-> (/ xp map-tile-dim)
-                  (Math/ceil)
-                  (- 1)
-                  (int))]
-       [yt xt]))   
-
+  (pixels->tile
+    [this]
+    "Returns this alert coordinates as map tile coordinates."
+    (let [[yp xp] (meters->pixels this)
+          res (resolution this)
+          yt (-> (/ yp map-tile-dim)
+                 (Math/ceil)
+                 (- 1)
+                 (int))
+          xt (-> (/ xp map-tile-dim)
+                 (Math/ceil)
+                 (- 1)
+                 (int))]
+      [yt xt]))   
+  
     (resolution
      [this]
      "Returns this alert map resolution in meters per pixel."
@@ -121,3 +121,32 @@
   {:pre [(latlon-valid? lat lon)]}
   "Returns the map tile coordinates [x y zoom] at a given lat, lon, and zoom."
   (get-maptile (Alert. lat lon zoom)))
+
+(defn meters->pixels-direct
+  [xm ym zoom]
+  "Directly converts x and y coordinates to pixel coordinates at zoom level,
+   without passing through latlon."
+  (let [res (/ initial-res (expt 2 zoom))
+        yp (-> (+ ym origin-shift)
+               (/ res))
+        xp (-> (+ xm origin-shift)
+               (/ res))]
+    [xp yp]))
+
+(defn meters->tile
+  [xm ym zoom]
+  "Returns the map tile coordinates [x y zoom] for a given x, y (in meters),
+   resolution (in meters) and zoom level."
+  (let [res (/ initial-res (expt 2 zoom))
+        [xp yp] (meters->pixels-direct xm ym zoom)
+        yt (-> (/ yp map-tile-dim)
+               (Math/ceil)
+               (- 1)
+               (int))
+        xt (-> (/ xp map-tile-dim)
+               (Math/ceil)
+               (- 1)
+                  (int))
+        yt-flipped (-> (- (expt 2 zoom) 1)
+                       (- yt))]
+    [xt yt-flipped zoom]))

--- a/src/clj/forma/gfw/cdm.clj
+++ b/src/clj/forma/gfw/cdm.clj
@@ -133,7 +133,7 @@
                (/ res))]
     [xp yp]))
 
-(defn meters->tile
+(defn meters->maptile
   [xm ym zoom]
   "Returns the map tile coordinates [x y zoom] for a given x, y (in meters),
    resolution (in meters) and zoom level."

--- a/src/clj/forma/gfw/cdm.clj
+++ b/src/clj/forma/gfw/cdm.clj
@@ -99,11 +99,11 @@
 ;; Map of lat/lon min and max values.
 (def latlon-range {:lat-min -90 :lat-max 90 :lon-min -180 :lon-max 180})
 
-(defn read-latlon
-  "Converts lat and lon values from string to number."
-  [lat lon]
-  {:pre [(= (type lat) java.lang.String), (= (type lon) java.lang.String)]}
-  [ (read-string lat) (read-string lon)])
+(defn read-string->num
+  "Convert strings to number."
+  [& s]
+  {:pre [(every? string? s)]}
+  (vec (map read-string s)))
 
 (defn latlon-valid?
   [lat lon]

--- a/src/clj/forma/hadoop/jobs/cdm.clj
+++ b/src/clj/forma/hadoop/jobs/cdm.clj
@@ -4,7 +4,7 @@ coordinates."
   (:use [cascalog.api]
         [forma.source.gadmiso :only (gadm->iso)]
         [forma.gfw.cdm :only (latlon->tile, read-string->num, latlon-valid?,
-                              meters->tile)]
+                              meters->maptile)]
         [forma.utils :only (positions)])
   (:require [forma.postprocess.output :as o]
             [forma.reproject :as r]

--- a/test/forma/gfw/cdm_test.clj
+++ b/test/forma/gfw/cdm_test.clj
@@ -14,16 +14,6 @@
 
 (tabular
  (fact
-   "Test read-latlon function."
-   (read-string->num ?lat ?lon) => ?result)
- ?lat ?lon ?result
- "41.850033" "-87.65005229999997" [41.850033 -87.65005229999997]
- 41.850033 -87.65005229999997 (throws AssertionError)
- "41.850033" -87.65005229999997 (throws AssertionError)
- 41.850033 "-87.65005229999997" (throws AssertionError))
-
-(tabular
- (fact
    "Test latlon-valid? function."
    (latlon-valid? ?lat ?lon) => ?result)
  ?lat ?lon ?result

--- a/test/forma/gfw/cdm_test.clj
+++ b/test/forma/gfw/cdm_test.clj
@@ -15,7 +15,7 @@
 (tabular
  (fact
    "Test read-latlon function."
-   (read-latlon ?lat ?lon) => ?result)
+   (read-string->num ?lat ?lon) => ?result)
  ?lat ?lon ?result
  "41.850033" "-87.65005229999997" [41.850033 -87.65005229999997]
  41.850033 -87.65005229999997 (throws AssertionError)
@@ -45,5 +45,16 @@
  -181 0 false
  181 0 false)
 
-
-
+(tabular
+ (fact
+   "Test meters->maptile function"
+   (meters->maptile ?x ?y ?z) => ?result)
+ ?x ?y ?z ?result
+ -1  1  1 [0 0 1]
+ -1  1  4 [7 7 4]
+  1  1  1 [1 0 1]
+  1  1  4 [8 7 4]
+ -1 -1  1 [0 1 1]
+ -1 -1  4 [7 8 4]
+  1 -1  1 [1 1 1]
+  1 -1  4 [8 8 4])

--- a/test/forma/hadoop/jobs/cdm_test.clj
+++ b/test/forma/hadoop/jobs/cdm_test.clj
@@ -8,12 +8,12 @@ namespace."
             [cascalog.ops :as c]))
 
 (tabular
- (fact "Test hansen->cdm function.  A valid lat-lon should produce the
+ (fact "Test hansen-latlon->cdm function.  A valid lat-lon should produce the
 specified row; but an invalid lat-lon will not produce a row."
    (hansen-latlon->cdm ?src ?zoom ?tres) => (produces ?row))
  ?src ?zoom ?tres ?row 
- [["-87.65005229999997" "41.850033" "1"]] 16 "32" [[16811 24364 16 131]]
- [["2000" "2000" "1"]] 16 "32" [])
+ [["-87.65005229999997,41.850033,1"]] 16 "32" [[16811 24364 16 131]]
+ [["2000,2000,1"]] 16 "32" [])
 
 (fact "Check that `forma->cdm` produces the expected output, ready for
 input into CartoDB table."

--- a/test/forma/hadoop/jobs/cdm_test.clj
+++ b/test/forma/hadoop/jobs/cdm_test.clj
@@ -10,7 +10,7 @@ namespace."
 (tabular
  (fact "Test hansen->cdm function.  A valid lat-lon should produce the
 specified row; but an invalid lat-lon will not produce a row."
-   (hansen->cdm ?src ?zoom ?tres) => (produces ?row))
+   (hansen-latlon->cdm ?src ?zoom ?tres) => (produces ?row))
  ?src ?zoom ?tres ?row 
  [["-87.65005229999997" "41.850033" "1"]] 16 "32" [[16811 24364 16 131]]
  [["2000" "2000" "1"]] 16 "32" [])


### PR DESCRIPTION
Adds support to cdm namespace for converting Hansen data from xy coordinates (in meters) to map tile coordinates.
