### PR TITLE
removed cartodb dep in order to avoid problem in uberjarring

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,6 @@
                  [org.clojure/tools.cli "0.1.0"]
                  [org.clojure/tools.logging "0.2.3"]
                  [clojure-csv/clojure-csv "1.3.2"]
-                 [cartodb-clj "1.1.1"]
                  [org.clojure/math.numeric-tower "0.0.1"]
                  [incanter/incanter-core "1.3.0"]
                  [clj-time "0.3.4"]

--- a/src/clj/forma/hadoop/jobs/cdm.clj
+++ b/src/clj/forma/hadoop/jobs/cdm.clj
@@ -2,7 +2,6 @@
   "Functions and Cascalog queries for converting data into map tile
 coordinates."
   (:use [cascalog.api]
-        [cartodb.playground :only (insert-rows delete-all big-insert)]
         [forma.source.gadmiso :only (gadm->iso)]
         [forma.gfw.cdm :only (latlon->tile, read-latlon, latlon-valid?)]
         [forma.utils :only (positions)])


### PR DESCRIPTION
Still getting this error when we include 

``` clojure
[cartodb-clj "1.1.1"]
```

in `project.clj`:

``` text
Caused by: java.util.zip.ZipException: duplicate entry: META-INF/LICENSE.txt
```

This pull req is a temporary fix.
