### PR TITLE
removed fire-series function

### DIFF
--- a/src/clj/forma/hadoop/jobs/timeseries.clj
+++ b/src/clj/forma/hadoop/jobs/timeseries.clj
@@ -93,7 +93,7 @@
   (when (seq tseries)
     (->> tseries
          (reductions schema/add-fires)
-         (schema/fire-series start))))
+         (thrift/TimeSeries* start))))
 
 (defn aggregate-fires
   "Converts the datestring into a time period based on the supplied

--- a/src/clj/forma/schema.clj
+++ b/src/clj/forma/schema.clj
@@ -1,10 +1,8 @@
 (ns forma.schema
+  "A set of functions to structure other queries."
   (:require [forma.date-time :as date]
-            [forma.reproject :as r]
-            [forma.thrift :as thrift]            
             [forma.utils :as u]
-            [forma.thrift :as thrift]
-            [clojure.string :as s]))
+            [forma.thrift :as thrift]))
 
 (defn create-timeseries
   "Create a TimeSeries from a period start index and a collection of timeseries
@@ -22,9 +20,9 @@
 
 (defn boundaries
   "Accepts a sequence of pairs of <initial time period, collection>
-  and returns the maximum start period and the minimum end period. For
-  example:
+  and returns the maximum start period and the minimum end period.
 
+  Example usage:
     (boundaries [0 [1 2 3 4] 1 [2 3 4 5]]) => [1 4]"
   [pair-seq]
   {:pre [(even? (count pair-seq))]}
@@ -36,26 +34,16 @@
 (defn adjust
   "Appropriately truncates the incoming timeseries values (paired with
   the initial integer period), and outputs a new start and both
-  truncated series. For example:
+  truncated series.
 
-    (adjust 0 [1 2 3 4] 1 [2 3 4 5])
-    ;=> (1 [2 3 4] [2 3 4])"
+  Example usage:
+    (adjust 0 [1 2 3 4] 1 [2 3 4 5]) => (1 [2 3 4] [2 3 4])"
   [& pairs]
   {:pre [(even? (count pairs))]}
   (let [[bottom top] (boundaries pairs)]
     (cons bottom
           (for [[x0 seq] (partition 2 pairs)]
             (into [] (u/trim-seq bottom top x0 seq))))))
-
-(defn fire-series
-  "Creates a `FireSeries` object from the supplied sequence of
-  `FireValue` objects."
-  ([start xs]
-     (fire-series start
-                  (dec (+ start (count xs)))
-                  xs))
-  ([start end xs]
-     (thrift/TimeSeries* start end xs)))
 
 (defn adjust-fires
   "Returns a TimeSeries object of fires that are within the bounds of

--- a/test/forma/hadoop/jobs/timeseries_test.clj
+++ b/test/forma/hadoop/jobs/timeseries_test.clj
@@ -33,18 +33,17 @@
 
 (future-fact?-
  "Add in test for results, here! Add another test for the usual
- aggregate-fires business.
+  aggregate-fires business.
 
-Also note that we're testing for truncation after march."
- "this results vector needs an overhaul:"
+  Also note that we're testing for truncation after march."
  [[1] [2]]
  (??- (-> (vec (concat (test-fires 4 100)
                        (test-fires 10 100)))
           (create-fire-series "32" "1970-01-01" "1970-03-01"))))
 
 (future-fact
- "Need to update this -- we want to check that the results of
-this query don't contain -9999."
+  "Need to update this -- we want to check that the results of this
+  query don't contain -9999."
  (let [results (-> (concat (test-chunks "precl" 10 1200)
                            (test-chunks "ndvi" 10 1200))
                    (vec)
@@ -55,10 +54,10 @@ this query don't contain -9999."
 
 (fact
   "Test running-fire-sum"
-  (let [fires-src [[[(schema/fire-value 0 0 0 10)
-                     (schema/fire-value 1 0 0 33)]]]
-        result [(schema/fire-series 0 [(schema/fire-value 0 0 0 10)
-                                       (schema/fire-value 1 0 0 43)])]]
+  (let [fires-src [[[(thrift/FireValue* 0 0 0 10)
+                     (thrift/FireValue* 1 0 0 33)]]]
+        result [(thrift/TimeSeries* 0 [(thrift/FireValue* 0 0 0 10)
+                                       (thrift/FireValue* 1 0 0 43)])]]
     (??<- [?vals]
           (fires-src ?fire-vals)
           (running-fire-sum 0 ?fire-vals :> ?vals)) => [result]))


### PR DESCRIPTION
Replaced `shema/fire-series` with the simpler `thrift/TimeSeries*` and fixed tests that had depended on `fire-series`.  Also adjusted docs.  Dealt with Issue #115.
