### PR TITLE
Fix #172 Incorporate new thrift api date handling, allowing use of nullable date field

### DIFF
--- a/src/clj/forma/source/static.clj
+++ b/src/clj/forma/source/static.clj
@@ -115,12 +115,12 @@
                                "?val"
                                nodata)]
     (<- [?tile-chunk]
-        (src ?dataset ?s-res ?t-res _ ?h ?v  _ ?id ?window)
+        (src ?dataset ?s-res ?t-res !date ?h ?v  _ ?id ?window)
         (p/flatten-window ?window :> ?data)
         (count ?data :> ?count)
         (= ?count chunk-size)
         (thrift/ModisChunkLocation* ?s-res ?h ?v ?id chunk-size :> ?tile-loc)
-        (thrift/DataChunk* ?dataset ?tile-loc ?data ?t-res :> ?tile-chunk))))
+        (thrift/DataChunk* ?dataset ?tile-loc ?data ?t-res :date !date :> ?tile-chunk))))
 
 (defn static-chunks
   "TODO: DOCS!"


### PR DESCRIPTION
Restores nullable `!date` field in `agg-chunks` and incorporates latest update to thrift API for dates. See issue #172 for discussion.
