### PR TITLE
Use == to check for nodata values to be dropped; fixes #175

### DIFF
--- a/src/clj/forma/source/rain.clj
+++ b/src/clj/forma/source/rain.clj
@@ -182,7 +182,7 @@
         mod-coords ["?mod-h" "?mod-v" "?sample" "?line"]]    
     (<- [?dataset ?m-res ?t-res !date ?mod-h ?mod-v ?sample ?line ?val]
         (rain-vals !date ?row ?col ?float-val)
-        (not= ?float-val nodata)
+        (== ?float-val nodata :> false)
         (double ?float-val :> ?val)
         (pix-tap :>> mod-coords)
         (p/add-fields "precl" "32" m-res :> ?dataset ?t-res ?m-res)


### PR DESCRIPTION
Tested in production. This one is good to go. Fixes issue #175
