### PR TITLE
improving rain filtering workflow

### DIFF
--- a/src/clj/forma/trends/stretch.clj
+++ b/src/clj/forma/trends/stretch.clj
@@ -39,7 +39,7 @@
         (let [res (persistent! result)
               start-idx (long beg)
               end-idx (long (dec (+ beg (count res))))]
-          (thrift/TimeSeries* start-idx end-idx  res))
+          (thrift/TimeSeries* start-idx end-idx res))
         (let [num-days (date/period-span target-res pd)]
           (recur more
                  (drop num-days day-seq)


### PR DESCRIPTION
Modified and added docs to forma/filter-query to allow faster screening by VCF using only VCF >= 25 pixels instead of joining on all VCF pixels before filtering by >= 25. Added rain step using forma/filter-query to screen rain by VCF before relatively slow ts stretching.
