### PR TITLE
Feature/fix trends

### DIFF
--- a/src/clj/forma/trends/analysis.clj
+++ b/src/clj/forma/trends/analysis.clj
@@ -78,10 +78,11 @@
                    (-> (i/solve (i/mult foc-mat (i/nrow ts-mat)))
                        (i/mmult focsum-mat)
                        (i/trace)))
-                 (catch Exception e))]
-    (if (string? output)
-      nil
-      (vec output))))
+                 (catch Throwable e
+                      (error (str "TIMESERIES ISSUES: " ts) e)))]
+    (if-not (and (nil? output)
+                 (string? output))
+      [output])))
 
 ;; Long-term trend characteristic; supporting functions 
 
@@ -131,7 +132,8 @@
                     (catch Throwable e
                       (error (str "TIMESERIES ISSUES: " ts ", "
                                   cofactors) e)))]
-    (if (string? output)
+    (if (or (nil? output)
+            (string? output))
       [nil nil]
       (vec output))))
 


### PR DESCRIPTION
Tweaked timeseries analysis functions using exception handling so that the number of output fields is correct (and filled with the appropriate number of `nil`). This addresses issue #192 and an `wrong number of fields` error that never made it into the issue tracker.
