### PR TITLE
updated midje version to work with lein 2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,4 +31,4 @@
                                   [midje-cascalog "0.4.0"]
                                   [incanter/incanter-charts "1.3.0"]]
                    :plugins [[lein-swank "1.4.4"]
-                             [lein-midje "1.0.8"]]}})
+                             [lein-midje "2.0.0-SNAPSHOT"]]}})


### PR DESCRIPTION
The `forma.source.hdf` test still fails locally for me, but this is a problem with my GDAL setup:

``` text
Caused by: java.lang.UnsatisfiedLinkError: org.gdal.gdal.gdalJNI.AllRegister()
```

But the testing works (and the `midje-color` plugin looks nice locally):

``` text
WORK TO DO: hp-filter produces correct results (filter_test.clj:40)
All claimed facts (422) have been confirmed. 
```
