### PR TITLE
Expanded docs; added precondition to general static query

### DIFF
--- a/src/clj/forma/hadoop/jobs/preprocess.clj
+++ b/src/clj/forma/hadoop/jobs/preprocess.clj
@@ -1,7 +1,7 @@
 (ns forma.hadoop.jobs.preprocess
   (:use cascalog.api
         [forma.hadoop.pail :only (to-pail)]
-        [forma.source.tilesets :only (tile-set)]
+        [forma.source.tilesets :as t]
         [cascalog.io :only (with-fs-tmp)])
   (:require [forma.hadoop.predicate :as p]
             [forma.hadoop.io :as io]
@@ -10,6 +10,43 @@
             [forma.source.static :as s]
             [forma.static :as static]
             [cascalog.ops :as c]))
+
+(defmain PreprocessStatic
+  "Use to process all static datasets. See the project wiki for
+   details on getting the correct files in place on HDFS.
+
+   Note that the Hansen and VCF datasets are handled differently
+   because they line up perfectly with the MODIS tiling scheme.
+
+   Locations can be specified as iso code keywords (e.g. :BRA :MEX) or
+   string tile vectors (e.g. \"[28 8]\" \"[29 9]\").
+
+   Usage:
+     hadoop jar forma-0.2.0-SNAPSHOT-standalone.jar \\
+                forma.hadoop.jobs.preprocess.PreprocessStatic \\
+                \"gadm\" \\
+                \"user/hadoop/border.txt\" \\
+                \"s3n://bucketname/pail-loc/\" \\
+                \"500\" \\
+                :VEN"
+  [dataset ascii-path pail-path s-res & locations]
+  {:pre [(string? s-res)
+         (not (nil? locations))]}
+  (with-fs-tmp [_ tmp-dir]
+    (let [tile-seq (if (= :all (read-string (first locations)))
+                     (apply t/tile-set (keys t/country-tiles))
+                     (apply t/tile-set (map read-string locations))) 
+          line-tap (hfs-textline ascii-path)
+          pix-tap  (p/pixel-generator tmp-dir s-res tile-seq)
+          agg ({"vcf" c/min "hansen" c/sum} dataset c/max)
+          chunker ({"vcf" s/static-modis-chunks
+                    "hansen" s/static-modis-chunks}
+                   dataset s/static-chunks)]
+      (->> (if (and (#{"hansen" "vcf"} dataset)
+                    (= "500" s-res))
+             (chunker static/chunk-size dataset agg line-tap pix-tap)
+             (chunker s-res static/chunk-size dataset agg line-tap pix-tap))
+           (to-pail pail-path)))))
 
 (defn rain-chunker
   "Like `modis-chunker`, for NOAA PRECL data files."
@@ -26,62 +63,9 @@
   [source-path sink-path s-res & locations]
   {:pre [(string? s-res)
          locations]}
-  (let [tiles (apply tile-set (map read-string locations))
+  (let [tiles (apply t/tile-set (map read-string locations))
         chunk-size static/chunk-size]
     (rain-chunker s-res chunk-size tiles source-path sink-path)))
-
-(defn static-chunker
-  "m-res - MODIS resolution. "
-  [m-res chunk-size tile-seq dataset agg ascii-path pail-path]
-  (with-fs-tmp [_ tmp-dir]
-    (let [line-tap (hfs-textline ascii-path)
-          pix-tap  (p/pixel-generator tmp-dir m-res tile-seq)]
-      (->> (s/static-chunks m-res chunk-size dataset agg line-tap pix-tap)
-           (to-pail pail-path)))))
-
-(defmain PreprocessStatic
-  "Use to process all static datasets, other than Hansen and VCF. See the
-   project wiki for details on getting the correct files in place on HDFS.
-
-   Usage: hadoop jar forma-0.2.0-SNAPSHOT-standalone.jar
-                 forma.hadoop.jobs.preprocess.PreprocessStatic \\
-                 \"gadm\" \" /user/hadoop/border.txt\" \\
-                 \"s3n://bucketname/pail-loc/\" \"500\" :VEN"
-  [dataset ascii-path output-path s-res & countries]
-  {:pre [(string? s-res)
-         (not (contains? #{"vcf" "hansen"} dataset))]}
-  (static-chunker s-res
-                  static/chunk-size
-                  (->> countries
-                       (map read-string)
-                       (apply tile-set))
-                  dataset
-                  ({"vcf" c/max "hansen" c/sum} dataset c/max)
-                  ascii-path
-                  output-path))
-
-(defmain PreprocessHansenVCF
-  "Use to process static Hansen and VCF datasets.
-
-  These are processed separately because they 1) line up perfectly
-  with the MODIS tiling system, and 2) at non-native resolution (these
-  come in 500m resolution) we aggregate them differently from the
-  other static datsets."
-  [dataset ascii-path pail-path s-res & countries]
-  {:pre [(string? s-res)
-         (#{"hansen" "vcf"} dataset)]}
-  (with-fs-tmp [_ tmp-dir]
-    (let [line-tap (hfs-textline ascii-path)
-          pix-tap  (->> countries
-                        (map read-string)
-                        (apply tile-set)
-                        (p/pixel-generator tmp-dir s-res))]
-      (->> (s/static-modis-chunks static/chunk-size
-                                  dataset
-                                  ({"vcf" c/min "hansen" c/sum} dataset c/max)
-                                  line-tap
-                                  pix-tap)
-           (to-pail pail-path)))))
 
 ;; ## Fires Processing
 ;;


### PR DESCRIPTION
See discussion in #202. To ensure that in the future the static preprocessing queries don't get mixed up - which may have caused pixel shifting per #202 - I added a precondition checking the dataset name, and expanded the documentation.
