### PR TITLE
Functions and tests to extract values from vectors by date

### DIFF
--- a/src/clj/forma/date_time.clj
+++ b/src/clj/forma/date_time.clj
@@ -271,7 +271,9 @@ in which `string` lies (according to the supplied resolution, `res`)."
 (defn convert-period-res
   "Convert a period from in-res to corresponding period at out-res.
 
-   By converting a period to a date, we get the first date within a period. Converting date to period, we get the period in which that first date falls, at the new resolution."
+   By converting a period to a date, we get the first date within a
+   period. Converting date to period, we get the period in which that
+   first date falls, at the new resolution."
   [res-in res-out period]
   (->> (period->datetime res-in period)
        (datetime->period res-out)))
@@ -290,18 +292,27 @@ in which `string` lies (according to the supplied resolution, `res`)."
 
      (date-str->vec-idx \"16\" \"2000-01-01\" [1 2 3] \"2000-12-01\")
      => nil"
-  [t-res v-start-dt v dt]
-  (let [start-idx (datetime->period t-res v-start-dt)
-        end-idx (dec (+ start-idx (count v)))
-        end-date (period->datetime t-res end-idx)]
-    (if (within-dates? v-start-dt end-date dt)
-      (- (datetime->period t-res dt) start-idx)
+  [t-res start-dt v dt]
+  (let [start-idx (datetime->period t-res start-dt)
+        idx (- (datetime->period t-res dt) start-idx)
+        length (count v)]
+    (if (and (<= idx (dec length))
+             (>= idx 0))
+      idx
       nil)))
 
 (defn get-val-at-date
   "Returns the value of a vector at the index corresponding to a given
-   date. Returns `nil` if date falls outside the range of dates implied
-   by the length of the vector
+   date. If there is no corresponding index (e.g. date comes before
+   start of series or after the end), returns `nil` by default.
+
+   Optional arguments:
+     `:out-of-bounds-val`: provide an alternative value to the `nil'
+     default if the date falls outside of the series.
+
+     `:out-of-bounds-idx`: choose a value from the series at the index
+     given, as an alternative to the default `nil' if the date falls
+     outside the series.
 
    Note: Because this function uses the period and date conversion
          functions, it will snap any date to the initial date of the
@@ -313,8 +324,11 @@ in which `string` lies (according to the supplied resolution, `res`)."
    
      (date-str->vec-idx \"16\" \"2000-01-01\" [2 4 6] \"2012-05-01\")
      => nil"
-  [t-res v-start-dt v dt]
-  (let [idx (date-str->vec-idx t-res v-start-dt v dt)]
+  [t-res start-dt v dt & {:keys [out-of-bounds-val out-of-bounds-idx]}]
+  (let [idx (date-str->vec-idx t-res start-dt v dt)]
     (if idx
-    (nth v idx)
-    nil)))
+      (nth v idx)
+      (or out-of-bounds-val
+          (if out-of-bounds-idx
+            (nth v out-of-bounds-idx))
+          nil))))

--- a/test/clj/forma/date_time_test.clj
+++ b/test/clj/forma/date_time_test.clj
@@ -116,4 +116,6 @@ month    1       12)
 (facts
   "Check that `get-val-at-date` outputs the correct index for a date"
   (get-val-at-date "16" "2000-01-01" [2 4 6] "2000-01-17") => 4
-  (get-val-at-date "16" "2000-01-01" [1 2 3] "2001-01-01") => nil)
+  (get-val-at-date "16" "2000-01-01" [1 2 3] "2001-01-01") => nil
+  (get-val-at-date "16" "2000-01-01" [2 4 6] "2005-01-01" :out-of-bounds-val 5) => 5
+  (get-val-at-date "16" "2000-01-01" [2 4 6] "2005-01-01" :out-of-bounds-idx 0) => 2)


### PR DESCRIPTION
`get-val-at-date` provides an easy way to extract the value for a specific date from a vector, based on the start date and temporal resolution of the series. It only works with MODIS-derived time series supported by the other functions in `datetime.clj`.
