### PR TITLE
clean-probs now handles missing values appropriately; tests updated (#267)

### DIFF
--- a/src/clj/forma/postprocess/output.clj
+++ b/src/clj/forma/postprocess/output.clj
@@ -6,7 +6,7 @@
         [forma.reproject :only (modis->latlon)]
         [forma.date-time :only (period->datetime datetime->period)]
         [clojure.string :only (split join)]
-        [forma.utils :only (moving-average average)]
+        [forma.utils :as u]
         [clojure.math.numeric-tower :only (round)]))
 
 (defn backward-looking-mavg
@@ -50,11 +50,12 @@
 
   Example usage:
     (clean-probs [0.1 0.2 0.3 0.4 0.5]) => [[10 15 20 30 40]]"
-  [ts]
+  [ts nodata]
   {:post [(= (count (flatten %)) (count ts))]}
-  [(vec (->> (backward-looking-mavg 3 ts)
+  (let [no-nodata-ts (u/replace-from-left nodata ts :default 0)]
+    [(vec (->> (backward-looking-mavg 3 no-nodata-ts)
              (reductions max)
-             (map #(round (* % 100)))))])
+             (map #(round (* % 100)))))]))
 
 (defn error-map
   "returns a vector indicating one of four possiblities: false

--- a/test/clj/forma/postprocess/output_test.clj
+++ b/test/clj/forma/postprocess/output_test.clj
@@ -19,8 +19,8 @@
 
 (facts "Test `clean-probs`"
   (let [ts [0.05 0.1 0.15 0.2 0.25 0.3 0.35 0.4]
-        cleaned-ts (clean-probs ts)]
-
+        cleaned-ts (clean-probs ts -9999.0)]
+    
     cleaned-ts => [[5 8 10 15 20 25 30 35]]
     
     ;; The value of the first cleaned timeseries should equal 100
@@ -29,4 +29,10 @@
 
     ;; Check that the length of the nested vector is equal to the
     ;; length of the original timeseries of probabilities.
-    (count (first cleaned-ts)) => (count ts)))
+    (count (first cleaned-ts)) => (count ts))
+
+  (let [ts [-9999.0 0.1 0.15 -9999.0 0.25 0.3 0.35 0.4]]
+    (clean-probs ts -9999.0)) => [[0 5 8 13 18 23 30 35]]
+
+  (let [ts [0.05 0.1 0.15 -9999.0 0.25 0.3 0.35 0.4]]
+    (clean-probs ts -9999.0))  => [[5 8 10 13 18 23 30 35]])


### PR DESCRIPTION
Addresses #267
