### PR TITLE
Avoid reprocessing tiles by using remove-tiles-by-iso

### DIFF
--- a/src/clj/forma/source/tilesets.clj
+++ b/src/clj/forma/source/tilesets.clj
@@ -104,3 +104,18 @@
                (country-tiles %)
                #{%}))
        (apply union)))
+
+(defn remove-tiles-by-iso
+  "Remove tiles from set of tiles for given `iso-codes`. Useful for
+   avoiding re-processing tiles unnecessarily.
+
+   Usage:
+     (tile-set :PER)
+     ;=> #{[10 9] [11 10] [9 9] [10 10] [11 9]}
+
+     (let [ts (tile-set :PER)]
+       (remove-tiles-by-iso ts :BRA))
+     ;=> #{[9 9] [10 10]}"
+  [t-s & iso-codes]
+  (let [remove-set (apply tile-set iso-codes)]
+    (apply disj t-s remove-set)))

--- a/test/clj/forma/source/tilesets_test.clj
+++ b/test/clj/forma/source/tilesets_test.clj
@@ -9,3 +9,7 @@
  [:MYS]        #{[27 8] [28 8] [29 8]}
  [:MYS [27 8]] #{[27 8] [28 8] [29 8]}
  [:MYS [8 7]]  #{[27 8] [28 8] [29 8] [8 7]})
+
+(fact
+  "Test `remove-tiles-by-iso`"
+  (remove-tiles-by-iso (tile-set :PER) :BRA) => #{[9 9] [10 10]})


### PR DESCRIPTION
Added `remove-tiles-by-iso`. From the docstring:

"Remove tiles from set of tiles for given `iso-codes`. Useful for avoiding re-processing tiles unnecessarily."
