### PR TITLE
support merging time series

### DIFF
--- a/src/clj/forma/utils.clj
+++ b/src/clj/forma/utils.clj
@@ -373,3 +373,76 @@
   (if (string? arg)
     (read-string arg)
     arg))
+
+(defn sorted-ts
+  "Accepts a map with date keys and time series values, and returns a
+  vector with the values appropriately sorted.
+
+  Example:
+    (sorted-ts {:2005-12-31 3 :2006-08-21 1}) => (3 1)"
+  [m]
+  (vals (into (sorted-map) m)))
+
+(defn same-len?
+  "Checks whether two collections have the same number of elements.
+
+   Usage:
+     (same-len? [1 2 3] [4 5 6])
+     ;=> true"
+  [coll1 coll2]
+  (= (count coll1) (count coll2)))
+
+(defn all-unique?
+  "Checks whether all the elements in `coll` are unique.
+
+   Usage:
+     (all-unique? [1 2 3])
+     ;=> true
+
+     (all-unique? [1 1 2])
+     ;=> false"
+  [coll]
+  (same-len? coll (set coll)))
+
+(defn inc-eq?
+  "Checks whether the first integer immediately preceeds the second one.
+
+   Usage:
+     (inc-eq? [1 2]) => true
+     (inc-eq? [0 2]) => false
+     (inc-eq? 1 2) => true
+     (inc-eq? 0 2) => false"
+  ([[a b]]
+     (inc-eq? a b))
+  ([a b]
+     (= (inc a) b)))
+
+(defn overlap?
+  "Checks for collisions between keys in provided maps.
+
+   Usage:
+     (overlap? {:a 1} {:b 2})
+     ;=> false
+
+     (overlap? {:a 1 :b 2} {:b 3})
+     ;=> true
+
+     (overlap? {:2006-01-01 1 :2006-01-17 2} {2006-01-17 30})
+     ;=> true"
+  ([& maps]
+     (let [all-ks (flatten (map keys maps))]
+       (not (all-unique? all-ks)))))
+
+(defn merge-no-overlap
+  "This function shadows the built-in `merge` function, but uses a
+   precondition to check for key collisions before merging maps.
+
+   Usage:
+     (merge-no-overlap {:2006-01-01 1 :2006-01-17 2} {:2006-02-02 3})
+     ;=> {:2006-01-01 1 :2006-01-17 2 :2006-02-02 3}
+
+     (merge-no-overlap {:2006-01-01 1 :2006-01-17 2} {2006-01-17 30})
+     ;=> (throws AssertionError)"
+  [& maps]
+  {:pre [(not (apply overlap? maps))]}
+  (apply merge maps))

--- a/test/clj/forma/date_time_test.clj
+++ b/test/clj/forma/date_time_test.clj
@@ -120,9 +120,6 @@ month    1       12)
   (get-val-at-date "16" "2000-01-01" [2 4 6] "2005-01-01" :out-of-bounds-val 5) => 5
   (get-val-at-date "16" "2000-01-01" [2 4 6] "2005-01-01" :out-of-bounds-idx 0) => 2)
 
-(fact "Check sorted-ts."
-  (sorted-ts {:2005-12-31 3 :2006-08-21 1}) => [3 1])
-
 (fact "Check key->period."
   (key->period "16" :2005-12-31) => 827
   (key->period "16" :2005-12-19) => 827
@@ -138,16 +135,6 @@ month    1       12)
 
 (fact "Check key-span."
   (key-span :2005-12-31 :2006-01-18 "16") => [:2005-12-19 :2006-01-01 :2006-01-17])
-
-(fact "Check all-unique?"
-  (all-unique? [1 2 3]) => true
-  (all-unique? [1 1 2]) => false)
-
-(fact "Check inc-eq?"
-  (inc-eq? [1 2]) => true
-  (inc-eq? [0 2]) => false
-  (inc-eq? 1 2) => true
-  (inc-eq? 0 2) => false)
 
 (fact "Check consecutive?"
   (consecutive? "16" [:2006-01-01 :2006-01-17]) => true
@@ -165,69 +152,6 @@ month    1       12)
 
 (fact "Check get-ts-map-start-idx"
   (get-ts-map-start-idx "16" {:2005-12-19 1 :2000-02-18 47}) => 693)
-
-(fact "Check overlap?"
-  (overlap? {:2006-01-01 1 :2006-01-17 2} {:2006-01-17 3 :2006-02-02 4}) => true
-  (overlap? {:2006-01-01 1 :2006-01-17 2} {:2006-02-02 3 :2006-02-18 4}) => false
-  (overlap? {:2006-01-01 1 :2006-01-17 2} {:2006-01-17 3 :2006-02-02 4}
-            {:2006-01-17 5 :2006-02-02 5} {:2006-01-17 10 :2006-02-02 10})
-  => true
-  (overlap? {:2006-01-01 1 :2006-01-17 2} {:2006-02-02 3 :2006-02-18 4}
-            {:2007-01-01 1 :2007-01-17 2} {:2007-02-02 3 :2007-02-18 4})
-  => false
-  (overlap? {:a 1}) => false)
-
-(tabular
- (fact "Check merge-ts with two maps."
-   (merge-ts ?update ?master ?new)
-   => ?result)
- ?master ?new ?update ?result
-
- ;; non-overlapping, update? true
- {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3}
- {:2012-02-18 4}
- true {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3 :2012-02-18 4}
- 
- ;; non-overlapping, update? false
- {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3}
- {:2012-02-18 4}
- false {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3 :2012-02-18 4}
- 
- ;; overlapping time series, update? true
- {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3}
- {:2012-02-02 4}
- true {:2012-01-01 1 :2012-01-17 2 :2012-02-02 4}
- 
- ;; overlapping time series, update? false
- {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3}
- {:2012-02-02 -1}
- false (throws AssertionError)
- 
- ;; overlapping time series, where new time series updates elements
- ;; in the middle of the master time series
- {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3 :2012-02-18 4}
- {:2012-01-17 -1 :2012-02-02 -1}
- true {:2012-01-01 1 :2012-01-17 -1 :2012-02-02 -1 :2012-02-18 4}
-
- ;; non-consecutive - hole in master series
- {:2012-01-01 1 :2012-01-17 2 :2013-01-01 3}
- {:2013-02-02 4}
- false {:2012-01-01 1 :2012-01-17 2 :2013-01-01 3 :2013-02-02 4}
- 
- ;; non-consecutive - hole in new series
- {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3}
- {:2012-02-18 4 :2012-03-21 5}
- false {:2012-01-01 1 :2012-01-17 2 :2012-02-02 3 :2012-02-18 4 :2012-03-21 5})
-
-(facts "Check merge-ts with any number of maps."
-  (merge-ts false {:a 1}) => {:a 1}
-  (merge-ts true {:a 1}) => {:a 1}
-  (merge-ts false {:a 1} {:b 2} {:c 3}) => {:a 1 :b 2 :c 3}
-  (merge-ts true {:a 1} {:b 2} {:c 3}) => {:a 1 :b 2 :c 3}
-  (merge-ts true {:a 1} {:b 2} {:b 99}) => {:a 1 :b 99}
-  (merge-ts true {:a 1} {:b 2} {:b 99} {:b 999}) => {:a 1 :b 999}
-  (merge-ts true {:a 1} {:b 2} {:b 999} {:b 99}) => {:a 1 :b 99}
-  (merge-ts false {:a 1} {:b 2} {:b 99}) => (throws AssertionError))
 
 (tabular
  (fact "Check ts-vec->ts-map"

--- a/test/clj/forma/utils_test.clj
+++ b/test/clj/forma/utils_test.clj
@@ -238,3 +238,26 @@
   "Test arg-parser"
   (arg-parser "ndvi") => (symbol "ndvi")
   (arg-parser "[\"ndvi\"]") => ["ndvi"])
+
+(fact "Check sorted-ts."
+  (sorted-ts {:2005-12-31 3 :2006-08-21 1}) => [3 1])
+
+(fact "Check all-unique?"
+  (all-unique? [1 2 3]) => true
+  (all-unique? [1 1 2]) => false)
+
+(fact "Check inc-eq?"
+  (inc-eq? [1 2]) => true
+  (inc-eq? [0 2]) => false
+  (inc-eq? 1 2) => true
+  (inc-eq? 0 2) => false)
+
+(fact "Check overlap?"
+  (overlap? {:a 1} {:b 2} {:b 3}) => true
+  (overlap? {:a 1} {:b 2}) => false
+  (overlap? {:a 1}) => false)
+
+(facts "Check merge-no-overlap"
+  (merge-no-overlap {:a 1}) => {:a 1}
+  (merge-no-overlap {:a 1} {:b 2} {:c 3}) => {:a 1 :b 2 :c 3}
+  (merge-no-overlap {:a 1} {:b 2} {:b 99}) => (throws AssertionError))


### PR DESCRIPTION
By converting time series vectors to maps with explicit dates for each period, we can robustly merge time series. The relevant functions (`merge-no-overlap` and `ts-map->ts-vec`) can check for and and flag (via an exception) overlapping time series, and check for and flag (via exception) or fill in holes in time series with a nodata value.
