### PR TITLE
Precondition checks for invalid beta and feature row matrices made w/nils

### DIFF
--- a/src/clj/forma/classify/logistic.clj
+++ b/src/clj/forma/classify/logistic.clj
@@ -78,7 +78,8 @@
 
   Precondition checks for empty beta/feature row matrices, which are
   created when `to-double-rowmat` operates on `nil`. This should never
-  happen in production.
+  happen in production, but if it does, the result of classification
+  would always be a probability of 0.5.
 
   Arguments: 
     beta-rowmat: DoubleMatrix row vector

--- a/test/clj/forma/classify/logistic_test.clj
+++ b/test/clj/forma/classify/logistic_test.clj
@@ -49,7 +49,7 @@
                  (to-double-rowmat [0 0 0])) => (to-double-rowmat [0.5]))
 
 (tabular
- (fact "Test `logistic-prob-wrap`"
+ (fact "Test `logistic-prob-wrap` preconditions."
    (logistic-prob ?beta-rowmat ?features-rowmat) => ?result)
    ?beta-rowmat ?features-rowmat ?result
    (to-double-rowmat [1 2]) (to-double-rowmat [0 0]) (to-double-rowmat [0.5])


### PR DESCRIPTION
`logistic-prob` should never have to deal with row matrices created with nil values:

``` clojure
(to-double-rowmat nil)
;=> #<DoubleMatrix []>
```
