### PR TITLE
Bump Cascalog to get newer Kryo dep w/o heap space error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                  [clj-time "0.3.4"]
                  [forma/gdal "1.8.0"]
                  [forma/jblas "1.2.1"]
-                 [cascalog "1.10.0"]
+                 [cascalog "1.10.1"]
                  [org.clojure/clojure-contrib "1.2.0"]
                  [cascalog-checkpoint "0.1.1"]
                  [backtype/dfs-datastores "1.1.3"]


### PR DESCRIPTION
Details about the error [in this gist](https://gist.github.com/robinkraft/5268273).
