### PR TITLE
Workaround for thrift issue makes paramBreak a required field; tests updated

### DIFF
--- a/dev/forma.thrift
+++ b/dev/forma.thrift
@@ -12,7 +12,7 @@ struct FormaValue {
   2: double shortDrop;
   3: double longDrop;
   4: double tStat;
-  5: optional double paramBreak;
+  5: double paramBreak;
 }
 
 struct NeighborValue {

--- a/src/clj/forma/thrift.clj
+++ b/src/clj/forma/thrift.clj
@@ -279,16 +279,10 @@
 
 (defn FormaValue*
   "Create a FormaValue."
-  [fire short long tstat & break]
+  [fire short long tstat break]
   {:pre [(instance? forma.schema.FireValue fire)
-         (every? float? [short long tstat])
-         (or (not break) (float? (first break)))]}
-  (let [[break] break
-        forma-value (FormaValue. fire short long tstat)]
-    (if break
-      (doto forma-value
-        (.setParamBreak break)))
-    forma-value))
+         (every? float? [short long tstat break])]}
+  (FormaValue. fire short long tstat break))
 
 (defn DataChunk*
   "Create a DataChunk."

--- a/src/jvm/forma/schema/FormaValue.java
+++ b/src/jvm/forma/schema/FormaValue.java
@@ -47,7 +47,7 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
   public double shortDrop; // required
   public double longDrop; // required
   public double tStat; // required
-  public double paramBreak; // optional
+  public double paramBreak; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -125,7 +125,6 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
   private static final int __TSTAT_ISSET_ID = 2;
   private static final int __PARAMBREAK_ISSET_ID = 3;
   private BitSet __isset_bit_vector = new BitSet(4);
-  private _Fields optionals[] = {_Fields.PARAM_BREAK};
   public static final Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -137,7 +136,7 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
     tmpMap.put(_Fields.T_STAT, new org.apache.thrift.meta_data.FieldMetaData("tStat", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
-    tmpMap.put(_Fields.PARAM_BREAK, new org.apache.thrift.meta_data.FieldMetaData("paramBreak", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+    tmpMap.put(_Fields.PARAM_BREAK, new org.apache.thrift.meta_data.FieldMetaData("paramBreak", org.apache.thrift.TFieldRequirementType.DEFAULT, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.DOUBLE)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(FormaValue.class, metaDataMap);
@@ -150,7 +149,8 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
     FireValue fireValue,
     double shortDrop,
     double longDrop,
-    double tStat)
+    double tStat,
+    double paramBreak)
   {
     this();
     this.fireValue = fireValue;
@@ -160,6 +160,8 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
     setLongDropIsSet(true);
     this.tStat = tStat;
     setTStatIsSet(true);
+    this.paramBreak = paramBreak;
+    setParamBreakIsSet(true);
   }
 
   /**
@@ -446,8 +448,8 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
         return false;
     }
 
-    boolean this_present_paramBreak = true && this.isSetParamBreak();
-    boolean that_present_paramBreak = true && that.isSetParamBreak();
+    boolean this_present_paramBreak = true;
+    boolean that_present_paramBreak = true;
     if (this_present_paramBreak || that_present_paramBreak) {
       if (!(this_present_paramBreak && that_present_paramBreak))
         return false;
@@ -482,7 +484,7 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
     if (present_tStat)
       builder.append(tStat);
 
-    boolean present_paramBreak = true && (isSetParamBreak());
+    boolean present_paramBreak = true;
     builder.append(present_paramBreak);
     if (present_paramBreak)
       builder.append(paramBreak);
@@ -587,12 +589,10 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
     sb.append("tStat:");
     sb.append(this.tStat);
     first = false;
-    if (isSetParamBreak()) {
-      if (!first) sb.append(", ");
-      sb.append("paramBreak:");
-      sb.append(this.paramBreak);
-      first = false;
-    }
+    if (!first) sb.append(", ");
+    sb.append("paramBreak:");
+    sb.append(this.paramBreak);
+    first = false;
     sb.append(")");
     return sb.toString();
   }
@@ -707,11 +707,9 @@ public class FormaValue implements org.apache.thrift.TBase<FormaValue, FormaValu
       oprot.writeFieldBegin(T_STAT_FIELD_DESC);
       oprot.writeDouble(struct.tStat);
       oprot.writeFieldEnd();
-      if (struct.isSetParamBreak()) {
-        oprot.writeFieldBegin(PARAM_BREAK_FIELD_DESC);
-        oprot.writeDouble(struct.paramBreak);
-        oprot.writeFieldEnd();
-      }
+      oprot.writeFieldBegin(PARAM_BREAK_FIELD_DESC);
+      oprot.writeDouble(struct.paramBreak);
+      oprot.writeFieldEnd();
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }

--- a/test/clj/forma/thrift_test.clj
+++ b/test/clj/forma/thrift_test.clj
@@ -53,16 +53,11 @@
   [0 1 (->> (map int [1 1 1 1]) IntArray. ArrayValue/ints)])
 
 (fact "Check creating and unpacking FormaValue objects."
-  (FormaValue* (FireValue. 1 1 1 1) 1.0 2.0 3.0) =>
-  (FormaValue. (FireValue. 1 1 1 1) 1.0 2.0 3.0)
+  (FormaValue* (FireValue. 1 1 1 1) 1.0 2.0 3.0 4.0) =>
+  (FormaValue. (FireValue. 1 1 1 1) 1.0 2.0 3.0 4.0)
 
-  (let [x  (FormaValue. (FireValue. 1 1 1 1) 1.0 2.0 3.0)]
-    (doto x
-      (.setParamBreak 4.0))
-    (FormaValue* (FireValue. 1 1 1 1) 1.0 2.0 3.0 4.0) => x)
-
-  (unpack (FormaValue* (FireValue. 1 1 1 1) 1.0 2.0 3.0)) =>
-  [(FireValue. 1 1 1 1) 1.0 2.0 3.0 0.0])
+  (unpack (FormaValue* (FireValue. 1 1 1 1) 1.0 2.0 3.0 4.0)) =>
+  [(FireValue. 1 1 1 1) 1.0 2.0 3.0 4.0])
 
 (fact "Check creating and unpacking DataChunk objects."
   (let [loc (->> (ModisChunkLocation. "500" 8 0 100 24000)


### PR DESCRIPTION
This fixes an issue where FormaValues were not being properly serialized into our pail. Specifically, the `paramBreak` field was getting reset to 0.0. [This gist](https://gist.github.com/robinkraft/5424034) demonstrates the problem. Could this be an issue with [Pail](https://github.com/nathanmarz/dfs-datastores) not correctly serializing optional fields inside nested objects? Packing and unpacking the thrift objects (without passing through a pail) works fine with optional fields.

Our workaround is to make the `paramBreak` field required. All tests pass.
