### PR TITLE
setup alias does standard lein install, forma-clj clone, and uberjarring from develop branch

### DIFF
--- a/dev/forma_bootstrap.sh
+++ b/dev/forma_bootstrap.sh
@@ -77,4 +77,7 @@ echo "source ~/.git-completion.bash" >> .bashrc
 # simple leiningen install via 'li'
 echo "alias li='cd /home/hadoop/bin; wget https://raw.github.com/technomancy/leiningen/preview/bin/lein; chmod u+x lein; ./lein; cd /home/hadoop;'" >> /home/hadoop/.bashrc
 
+# alias to do standard forma-clj setup
+setup="li; git clone git://github.com/reddmetrics/forma-clj.git; cd forma-clj; uj; cd ~/;"
+
 exit 0


### PR DESCRIPTION
Alias makes it simpler to get the cluster up and running:

``` bash
# installs lein
# clones forma-clj
# run lein do deps, compile :all, uberjar

setup
```
