### PR TITLE
HOTFIX: force non-interactive install of screen

### DIFF
--- a/dev/forma_bootstrap.sh
+++ b/dev/forma_bootstrap.sh
@@ -12,14 +12,27 @@ sources=/etc/apt/sources.list
 hadoop_lib=/home/hadoop/native/Linux-amd64-64
 
 # make sure apt repos are up to date
+#sudo apt-get update
+echo "updating keys"
+gpg --keyserver pgpkeys.mit.edu --recv-key 8B48AD6246925553
+gpg -a --export 8B48AD6246925553 | sudo apt-key add -
+gpg --keyserver pgpkeys.mit.edu --recv-key 6FB2A1C265FFB764
+gpg -a --export 6FB2A1C265FFB764 | sudo apt-key add -
+echo "apt-get update"
 sudo apt-get update
 
 # Start with screen.
-sudo apt-get -y --force-yes install screen
+echo "Installing screen et al."
+# http://serverfault.com/questions/209303/how-can-i-install-a-system-with-apt-get-without-ncurses-configuration-screens
+# http://stackoverflow.com/questions/8170691/automate-install-mysql-server-and-postfix-remotely
+# http://serverfault.com/questions/238679/unable-to-force-debian-to-do-unattended-install-libc6-wants-interactive-confi
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes screen
 sudo apt-get -y --force-yes install exim4
-sudo apt-get -y --force-yes install tmux
+#sudo apt-get -y --force-yes install tmux
 
 # add stuff for notifications
+echo "install stuff for notifications"
+sudo apt-get install libxml-xpath-perl
 sudo apt-get -y install python-pip
 sudo pip install awscli
 
@@ -27,7 +40,10 @@ sudo pip install awscli
 sudo apt-get -y --force-yes install htop
 
 # Install libhdf4
+echo "installing libhdf4"
 sudo aptitude -fy install libhdf4-dev
+
+echo "Installing FWTools, Java bindings, etc."
 
 # Install FWTools, (GDAL 1.8.0)
 wget -S -T 10 -t 5 http://$bucket.s3.amazonaws.com/$fwtools
@@ -44,6 +60,7 @@ sudo tar -C $hadoop_lib --strip-components=2 -xvzf $native
 sudo tar -C $hadoop_lib --strip-components=1 -xvzf $jblas
 sudo chown --recursive hadoop $hadoop_lib
 
+echo "configuring hadoop-env"
 # Add proper configs to hadoop-env.
 echo "export LD_LIBRARY_PATH=/usr/local/fwtools/usr/lib:$hadoop_lib:\$LD_LIBRARY_PATH" >> /home/hadoop/conf/hadoop-user-env.sh
 echo "export JAVA_LIBRARY_PATH=$hadoop_lib:\$JAVA_LIBRARY_PATH" >> /home/hadoop/conf/hadoop-user-env.sh


### PR DESCRIPTION
This is a workaround for an unexpected upgrade to `libc6` happening while installing `screen`. By default the upgrade requires user interaction, which causes EMR bootstrapping to hang forever, and eventually fail. This command works:

`sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes --force-yes screen`

http://serverfault.com/questions/238679/unable-to-force-debian-to-do-unattended-install-libc6-wants-interactive-confi
