### PR TITLE
Fix Uberjar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
   :jvm-opts ["-XX:MaxPermSize=128M"
              "-XX:+UseConcMarkSweepGC"
              "-Xms1024M" "-Xmx1048M" "-server"]
+  :main nil
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/tools.cli "0.1.0"]
                  [org.clojure/tools.logging "0.2.3"]

--- a/project.clj
+++ b/project.clj
@@ -26,11 +26,10 @@
                  [backtype/dfs-datastores-cascading "1.2.0"]
                  [org.apache.thrift/libthrift "0.8.0"
                   :exclusions [org.slf4j/slf4j-api]]
-                 [net.lingala.zip4j/zip4j "1.3.1"]
-]
+                 [net.lingala.zip4j/zip4j "1.3.1"]]
   :aot [forma.hadoop.pail, forma.schema, #"forma.hadoop.jobs.*"]
-  :profiles {:dev {:dependencies [[org.apache.hadoop/hadoop-core "0.20.2-dev"]
-                                  [cascalog/midje-cascalog "1.10.2-SNAPSHOT"]
+  :profiles {:provided {:dependencies [[org.apache.hadoop/hadoop-core "0.20.2-dev"]]}
+             :dev {:dependencies [[cascalog/midje-cascalog "1.10.2-SNAPSHOT"]
                                   [incanter/incanter-charts "1.3.0"]]
                    :plugins [[lein-swank "1.4.4"]
                              [lein-midje "3.0-beta1"]


### PR DESCRIPTION
This error probably showed up because of some Leiningen change - @robinkraft, you probably upgraded automatically or something since the last run.

This moves the Hadoop dependency to "provided". That makes it available for compilation, but doesn't include the source files in the final uberjar. "dev" dependencies are really just for tests and local REPLage, which is why I kept Midje, etc over there.

Have at it, boys!